### PR TITLE
only future training programs can be deleted, more program test data …

### DIFF
--- a/Controllers/TrainingProgramController.cs
+++ b/Controllers/TrainingProgramController.cs
@@ -133,7 +133,7 @@ namespace BangazonAPI.Controllers
             return new StatusCodeResult(StatusCodes.Status204NoContent);
         }
 
-        // DELETE a training program at that id from the db
+        // DELETE a training program at that id from the db ONLY if the program's date is in the future
         [HttpDelete("{id}")]
         public IActionResult Delete(int id)
         {
@@ -148,7 +148,16 @@ namespace BangazonAPI.Controllers
                 return NotFound();
             }
 
-            _context.TrainingProgram.Remove(trainingProgram);
+            int dateDifference = DateTime.Compare(trainingProgram.StartDate, DateTime.Today);
+            if (dateDifference > 0)
+            {
+                _context.TrainingProgram.Remove(trainingProgram);
+            }
+            else
+            {
+                return BadRequest(ModelState);
+            }
+
             _context.SaveChanges();
 
             return Ok(trainingProgram);

--- a/Data/DBInitializer.cs
+++ b/Data/DBInitializer.cs
@@ -181,15 +181,23 @@ namespace BangazonAPI.Data
                 {
                     new TrainingProgram { 
                         Name = "Doing Your Best",
-                        MaxAttendees = 12
+                        MaxAttendees = 12,
+                        StartDate = new DateTime(2018, 8, 28, 2,3,0)
                     },
                     new TrainingProgram { 
                         Name = "Excelling at Excel",
-                        MaxAttendees = 21
+                        MaxAttendees = 21,
+                        StartDate = new DateTime(2017, 8, 28, 2,3,0)
                     },
                     new TrainingProgram { 
                         Name = "Bring Your Things",
-                        MaxAttendees = 3
+                        MaxAttendees = 3,
+                        StartDate = new DateTime(2016, 7, 28, 2,3,0)
+                    },
+                    new TrainingProgram { 
+                        Name = "Do Life Better",
+                        MaxAttendees = 45,
+                        StartDate = new DateTime(2015, 7, 28, 2,3,0)
                     }
                 };
                 


### PR DESCRIPTION
Fixes #9 .

Changes proposed in this pull request:
 - added logic to allow the deletion of only training programs that are happening in the future
 - wrote additional training program seed data for easy testing

How to test:
 - open DB browser for SQLite, but do not yet open any database file
 - delete any Migrations folder you may have already created in the cloned repo
 - delete bang.db if you have one, since the following commands will create a new one
 - dotnet ef migrations add InitializeDatabase
 - dotnet ef database update
 - dotnet run
 - now open the bang.db file in DB browser
 - try deleting a future training program, which should result in an OK
 - now try deleting a past program, which should return a Bad Request

@EnRonSwanson/